### PR TITLE
Updated with VPNKit 6.9.0

### DIFF
--- a/ConsumerVPN/SDKInitializer/SDKInitializer.m
+++ b/ConsumerVPN/SDKInitializer/SDKInitializer.m
@@ -15,14 +15,6 @@
 
 @implementation SDKInitializer
 
-+ (NSString *)baseURL {
-    return @"https://api.wlvpn.com/v3/";
-}
-
-+ (NSArray<NSString *> *)backupURLs {
-    return @[];
-}
-
 /**
  * Builds a VPNAPIManager object for various api and connection adapter settings.
  *
@@ -48,8 +40,6 @@
     NSURL *coreDataUrl = [NSURL fileURLWithPath:[documentsDirectory stringByAppendingPathComponent:@"VPNKit.sqlite"]];
     
     NSDictionary *apiAdapterOptions = @{
-        kV3BaseUrlKey:          [self baseURL],
-        kV3AlternateUrlsKey:    [self backupURLs],
         kV3ApiKey:              apiKey,
         kV3CoreDataURL:         coreDataUrl,
         kV3ServiceNameKey:      brandName
@@ -65,8 +55,6 @@
         kIKEv2RemoteIdentifier:             @"vpn.wlvpn.com",
         kVPNSharedSecretKey:                @"vpn",
         kIKEv2KeychainServiceName:          apiAdapter.passwordServiceName,
-        kIKEv2V3BaseUrlKey:                 [self baseURL],
-        kIKEv2V3AlternateUrlsKey:           [self backupURLs],
     };
     
     NSMutableArray *adapters = [NSMutableArray arrayWithCapacity:2];
@@ -93,8 +81,6 @@
         kVPNDefaultProtocolKey: defaultProtocol,
         kCityPOPHostname:       @"wlvpn.com",
         kBundleNameKey:         brandName,
-        kV3BaseUrlKey:          [self baseURL],
-        kV3AlternateUrlsKey:    [self backupURLs]
     };
     
     VPNAPIManager *apiManager = [[VPNAPIManager alloc] initWithAPIAdapter:apiAdapter
@@ -120,14 +106,8 @@
     wgConfig.brandName = brandName;
     wgConfig.useAPIKey = NO;
     wgConfig.uuid = uuid; //[apiAdapter getOption:kV3UUIDKey];
-    wgConfig.apiURL = [NSString stringWithFormat:@"%@wireguard", [self baseURL]];
     wgConfig.apiKey = apiKey;
     wgConfig.extensionName = [bundleID stringByAppendingString:@".network-extension"];
-    NSMutableArray *alternateURLs = [NSMutableArray new];
-    for (NSString *alternateURL in [self backupURLs]) {
-        [alternateURLs addObject:[NSString stringWithFormat:@"%@wireguard", alternateURL]];
-    }
-    wgConfig.backupURL = alternateURLs;
     
     return [[WireGuardAdapter alloc] initWithConfiguration:wgConfig];
 }

--- a/SDK/README iOS.md
+++ b/SDK/README iOS.md
@@ -2,80 +2,82 @@
 
 VPNKit is the API and connection SDK for the WLVPN platform.
 
-## Dependencies
+# Table of contents
+1. [Dependencies](#dependencies)
+2. [Minimum Requirements](#minimum-requirements)
+3. [Project Setup](#project-setup)
+    1. [Add the required permissions for the app](#add-the-required-permissions-for-the-app)
+4. [Initialize the app](#initialize-the-app)
+    1. [VPNConfiguration](#vpnConfiguration)
+    2. [VPNAPIManager](#vpnapimanager)
+    3. [Adapters](#adapters)
+5. [Notifications](#notifications)
 
-The application has no external dependencies. It includes a copy of CocoaLumberjack for logging purposes. You can use
-this copy of CocoaLumberjack in your own application.
 
-## Minimum Requirements
- - iOS 14.0, macOS Mojave 10.14
- - API key access token
- Supports iPhone, iPad, Mac
+# Dependencies
+The application has no external dependencies. It includes a copy of CocoaLumberjack for logging purposes. You can use this copy of CocoaLumberjack in your own application.
 
-See: [Get Started](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/Get%20Started.md)
 
-## Project Setup
+# Minimum Requirements
+##### Operating Systems
+- iOS    13.0 +
+- iPadOS 13.0 +
+- macOS  10.15 +
+- tvOS   17.0 +
 
-The VPNKit framework needs to be linked into your project. You will also need to link at least one API adapter. The API adapter is linked as a static library while the framework is included and embedded in the project. 
+##### Access
+- API key and suffix, provided by your WLVPN representative.
 
-The framework is a "fat" binary, which should work in both the simulator and on a device. 
+##### Supported OS
+- iOS
+- iPadOS
+- macOS
+- tvOS
 
-See:[VPNKit iOS Guide](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/VPNKit%20iOS%20Guide.md)
 
-## Notifications
+# Project Setup
+1. Copy the VPNKit SDKs (VPNKit, VPNV3APIAdapter) from iOS_Fat (for simulator/development) or iOS_ARM (for production releases) or XCFrameworks to the SDK folder of the project.
+    
+2. Copy the VPNKitNetworkExtensionAdapters SDKs (VPKWireGuardAdapter, VPKWireGuardExtension) from iOS_ARM (for production releases) or macOS to the SDK folder of the project.
 
-The framework uses`NSNotification` and `NSNotificationCenter` to handle asynchronous actions. You call a framework 
-function and it will perform asynchronous actions. At various points during the action, a notification will be sent 
-out that allows your client to respond to the event. 
+- You can find the VPNKit changelog in its subfolder.
+        
+> Refer to: [Changelog](../Documentation/Changelog.md)
 
-### Example events:
 
-```
-VPNConnectionWillBeginNotification
-VPNConnectionSucceededNotification
-VPNServerUpdateWillBeginNotification
-VPNServerUpdateSucceededNotification
-```
+##### Add the required permissions for the app
+Add the required permissions for the app in the ***project file*** and initialize the app using the
+[Primary Objects](#primary-objects).
+> Refer: [VPNKit iOS Guide](../Documentation/VPNKit%20iOS%20Guide.md) 
 
-See: [Notifications Documentation](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/Notifications.md)
+# Initialize the app
+Initialize the app with the provided `APIKey`, `suffix` and `brandName`, `configName`
+> Refer: [Initializers](../Documentation/Initializers.md) 
 
 
 ## Primary Objects
 
-### VPNConfiguration
+##### VPNConfiguration
+The `VPNConfiguration` represents the current state of the VPN framework. It contains objects like user credentials, their account information, current selected city/country/server, and specific configuration options. You can monitor for changes in this class using either KVO or NotificationCenter. Each property will fire off a notification both before and after it changes internally. The `VPNConfiguration` is a singleton and can be accessed in the "vpnConfiguration" property of VPNAPIManager. You should not hold a separate reference to the VPNConfiguration. You should access it from the VPNAPIManager.
 
-The VPNConfiguration represents the current state of the VPN framework. It contains objects like user credentials, their account information, current selected city/country/server, and specific configuration
-options. You can monitor for changes in this class using either KVO or NotificationCenter. Each property
-will fire off a notification both before and after it changes internally. The VPNConfiguration is a singleton and can be accessed in the "vpnConfiguration" property of VPNAPIManager. You should not hold a separate reference to the VPNConfiguration. You should access it from the VPNAPIManager.
+> Refer: [VPNConfiguration](../Documentation/VPNConfiguration.md)
 
-See: [VPNConfiguration Documentation](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/VPNConfiguration.md)
+##### VPNAPIManager
+The `VPNAPIManager` is the primary object you will use to interact with `VPNKit`. It will perform all its actions using the attached VPNConfiguration. The `VPNAPIAdapter` manages its own Core Data store; it should not conflict with any store you have in your application. 
+> Refer: [APIManager](../Documentation/APIManager.md)
 
+##### Adapters
+There are two types of adapters in VPNKit: `Connection Adapters` and `API Adapters`.
+An API Adapter is used to connect to an API. The only adapter you will need to worry about is the V3APIAdapter. This connects to the current version of the VPN backend and will handle retrieval of API resources. 
+A Connection Adapter is used to connect to specific VPN protocols. The main adapter usable on iOS, macOS and tvOS is the `NEVPNManagerAdapter`. This adapter interfaces with the Apple provided NEVPNManager interface, to provide system supported VPN connections.
+ It supports IKEv2 and IPSec based connections. Due to limitations with iOS, this is the only adapter we support on iOS. The simulator for iOS does not support VPN connections. On the simulator, we simulate connections with the VPNConnectionTestAdapter. This can also be used to support UI tests in the iOS simulator.
+  
+> Refer: [Adapters](../Documentation/Adapters.md)
 
-### VPNAPIManager
+# Notifications
 
-The VPNAPIManager is the primary object you will use to interact with VPNKit. It will perform all its actions using the attached VPNConfiguration. The VPNAPIAdapter manages its own Core Data store; it should not conflict with any store you have in your application. 
+You call a framework function and it will perform asynchronous actions. At various points during the action, a notification will be sent out that allows you to respond to the event. 
+> Refer: [Notifications](../Documentation/Notifications.md)
 
-See: [VPNAPIManager Documentation](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/APIManager.md)
+> To get the necessary assets/SDK, please contact support@wlvpn.com
 
-
-#### Adapters
-
-There are two types of adapters in VPNKit: Connection adapters and API adapters. 
-
-An API adapter is used to connect to an API. The only adapter you will need to worry about is the V3APIAdapter. This connects to the current version of the VPN backend and will handle retrieval of API resources.
-
-A connection adapter is used to connect to specific VPN protocols. The main adapter usable on macOS and iOS is the NEVPNManagerAdapter. This adapter interfaces with the Apple provided NEVPNManager interface to provide system supported VPN connections. It supports IKEv2 and IPSec based connections. Due to limitations with iOS, this is the only adapter we support on iOS. The simulator for iOS does not support VPN connections. On the simulator, we simulate connections with the VPNConnectionTestAdapter. This can also be used to support UI tests in the iOS simulator. 
-
-See: [Adapters Documentation](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/Adapters.md)
-
-
-#### VPNAPIInitializer
-
-The framework is best initialized using Objective-C. 
-
-See: [VPNAPIInitializer Documentation](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/Initializers.md)
-
-
-To get the necessary assets/SDK, please contact support@wlvpn.com
-
- 


### PR DESCRIPTION
- Moved documentation inside SDK folder
- Base URL and API mirrors no longer needed to provide by client.