### PR TITLE
Update ConsumerVPN Sample Apps to VPNKit v7.1.1

### DIFF
--- a/ConsumerVPN.xcodeproj/project.pbxproj
+++ b/ConsumerVPN.xcodeproj/project.pbxproj
@@ -234,9 +234,7 @@
 		F66ED5172CFF4C1A001F6DF5 /* OpenVPN Implementation.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "OpenVPN Implementation.md"; sourceTree = "<group>"; };
 		F66ED5182CFF4C1A001F6DF5 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		F66ED5192CFF4C1A001F6DF5 /* Traffic counter for OpenVPN.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "Traffic counter for OpenVPN.md"; sourceTree = "<group>"; };
-		F66ED51A2CFF4C1A001F6DF5 /* Upgrade5to6.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Upgrade5to6.md; sourceTree = "<group>"; };
 		F66ED51B2CFF4C1A001F6DF5 /* VPNConfiguration.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = VPNConfiguration.md; sourceTree = "<group>"; };
-		F66ED51C2CFF4C1A001F6DF5 /* VPNKit 5.x - 6.x Upgrade Guide.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = "VPNKit 5.x - 6.x Upgrade Guide.pdf"; sourceTree = "<group>"; };
 		F66ED51D2CFF4C1A001F6DF5 /* VPNKit iOS Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "VPNKit iOS Guide.md"; sourceTree = "<group>"; };
 		F66ED51E2CFF4C1A001F6DF5 /* VPNKit macOS Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "VPNKit macOS Guide.md"; sourceTree = "<group>"; };
 		F66ED51F2CFF4C1A001F6DF5 /* Wireguard.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Wireguard.md; sourceTree = "<group>"; };
@@ -620,9 +618,7 @@
 				F66ED5172CFF4C1A001F6DF5 /* OpenVPN Implementation.md */,
 				F66ED5182CFF4C1A001F6DF5 /* README.md */,
 				F66ED5192CFF4C1A001F6DF5 /* Traffic counter for OpenVPN.md */,
-				F66ED51A2CFF4C1A001F6DF5 /* Upgrade5to6.md */,
 				F66ED51B2CFF4C1A001F6DF5 /* VPNConfiguration.md */,
-				F66ED51C2CFF4C1A001F6DF5 /* VPNKit 5.x - 6.x Upgrade Guide.pdf */,
 				F66ED51D2CFF4C1A001F6DF5 /* VPNKit iOS Guide.md */,
 				F66ED51E2CFF4C1A001F6DF5 /* VPNKit macOS Guide.md */,
 				F66ED51F2CFF4C1A001F6DF5 /* Wireguard.md */,

--- a/ConsumerVPN/README.md
+++ b/ConsumerVPN/README.md
@@ -5,7 +5,7 @@
 ![Supports iOS](https://img.shields.io/badge/iOS-fat--binary-blue)
 ![Supports ARM](https://img.shields.io/badge/ARM-arm64-informational)
 ![XCFramework Included](https://img.shields.io/badge/XCFramework-included-success)
-[![VPNKit 7.1.0](https://img.shields.io/badge/VPNKit-7.1.0-brightgreen)](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/Documentation/README.md)
+[![VPNKit 7.1.1](https://img.shields.io/badge/VPNKit-7.1.1-brightgreen)](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/Documentation/README.md)
 
 ConsumerVPN is a ready-to-brand application built with Swift and the WLVPN VPN SDK. It provides a foundation for your own VPN app and serves as a complete guide for integrating the WLVPN VPN SDK.(VPNKit).
 

--- a/ConsumerVPN/SDKInitializer/SDKInitializer.m
+++ b/ConsumerVPN/SDKInitializer/SDKInitializer.m
@@ -87,8 +87,8 @@
                                                        connectionAdapters:adapters
                                                                andOptions:apiManagerOptions];
     
-    // ensure that connections are not killed off when the app dies during an active connection
-    [apiManager.vpnConfiguration setOption:@YES forKey:kVPNStayConnectedOnQuit];
+    // Ensures that connections are not killed off when the app dies during an active connection
+    [apiManager.vpnConfiguration setStayConnectedOnQuit:YES];
     
     return apiManager;
 }

--- a/SDK/Documentation/Changelog.md
+++ b/SDK/Documentation/Changelog.md
@@ -1,5 +1,13 @@
 # VPNKit Changelog
 
+## VPNKit 7.1.1
+
+### Improvements
+- `sortedServer()` in `City` and `Country` now returns the latest updated server list, not cached data.
+
+### Breaking Changes
+- Renamed property from `shouldSkipVirtualServers` (getter: `isVirtualServersSkipped`) to `skipVirtualServerInLoadBalance` (getter: `shouldSkipVirtualServerInLoadBalance`) in `VPNConfiguration` class.
+
 ## VPNKit 7.1.0
 
 ### New Items

--- a/SDK/Documentation/README.md
+++ b/SDK/Documentation/README.md
@@ -1,6 +1,6 @@
 # VPNKit Version
 ------
-The latest version of the WLVPN Apple SDK is 7.1.0
+The latest version of the WLVPN Apple SDK is 7.1.1
 
 ## Getting started
 

--- a/SDK/Documentation/VPNConfiguration.md
+++ b/SDK/Documentation/VPNConfiguration.md
@@ -4,24 +4,24 @@
 # Properties
 
 ```markdown
-- `stayConnectedOnQuit`             : Bool - If true, the VPN will stay connected on quit. If false, the VPN will not stay  connected on quit.
-- `onDemandConfiguration`           : VPNOnDemandConfiguration -  An object that represents on-Demand rules.
-- `user`                            : User - An object that represents the current *login credentials*. Login will create a User and assign one or more accounts.
-- `server`                          : Server - An object for which a connection should be attempted, or that the user is currently connected to.
-- `city`                            : City - An object for which a connection should be attempted, or that the user is currently connected to.
-- `country`                         : Country - An object for which a connection should be attempted, or that the user is currently connected to.
-- `currentLocation`                 : VPNCurrentLocationModel - The current location model for the current vpnConfiguration user location.
-- `selectedProtocol`                : VPNProtocol - The currently selected VPN protocol.
-- `defaultProtocol`                 : VPNProtocol - The default VPN protocol. It can be set at `VPNAPIManager` initialization. 
-- `usingAutoselectedCountry`        : BOOL - If true country will be selected automatically else user has to provide.
-- `usingAutoselectedServer`         : BOOL - If true server will be selected automatically else user has to provide..
-- `usingAutoselectedCity`           : BOOL - If true city will be selected automatically else user has to provide..
-- `allowCityOnlySelection`          : BOOL - If true user can provide city only option.
-- `isMultihopEnabled`               : BOOL - If true multihop is enabled and maximum 2 cities are supported as entry and exit.
-- `multihopCities`                  : [City] - The list of cities for multihop. Order is important, the first element is the entry city, the last element is the exit city.
-- `connectedServers`                : [Server] - Read only. The list of connected servers for multihop after connection.
-- `isVirtualServersSkipped`         : BOOL - If true, when establishing connnection with Optimal Location, the virtual servers won't be taken into account.
-- `serverFeatures`                  : NSSet<NSNumber *> - The best available server for the city is selected based on the provided set of VPNServerFeature enum values.
+- `stayConnectedOnQuit`                     : Bool - If true, the VPN will stay connected on quit. If false, the VPN will not stay  connected on quit.
+- `onDemandConfiguration`                   : VPNOnDemandConfiguration -  An object that represents on-Demand rules.
+- `user`                                    : User - An object that represents the current *login credentials*. Login will create a User and assign one or more accounts.
+- `server`                                  : Server - An object for which a connection should be attempted, or that the user is currently connected to.
+- `city`                                    : City - An object for which a connection should be attempted, or that the user is currently connected to.
+- `country`                                 : Country - An object for which a connection should be attempted, or that the user is currently connected to.
+- `currentLocation`                         : VPNCurrentLocationModel - The current location model for the current vpnConfiguration user location.
+- `selectedProtocol`                        : VPNProtocol - The currently selected VPN protocol.
+- `defaultProtocol`                         : VPNProtocol - The default VPN protocol. It can be set at `VPNAPIManager` initialization. 
+- `usingAutoselectedCountry`                : BOOL - If true country will be selected automatically else user has to provide.
+- `usingAutoselectedServer`                 : BOOL - If true server will be selected automatically else user has to provide..
+- `usingAutoselectedCity`                   : BOOL - If true city will be selected automatically else user has to provide..
+- `allowCityOnlySelection`                  : BOOL - If true user can provide city only option.
+- `isMultihopEnabled`                       : BOOL - If true multihop is enabled and maximum 2 cities are supported as entry and exit.
+- `multihopCities`                          : [City] - The list of cities for multihop. Order is important, the first element is the entry city, the last element is the exit city.
+- `connectedServers`                        : [Server] - Read only. The list of connected servers for multihop after connection.
+- `shouldSkipVirtualServerInLoadBalance`    : BOOL - If true, when establishing connnection with Optimal Location, the virtual servers won't be taken into account.
+- `serverFeatures`                          : NSSet<NSNumber *> - The best available server for the city is selected based on the provided set of VPNServerFeature enum values.
 ```
 
 # Methods

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -9,5 +9,5 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-MARKETING_VERSION = 7.1.0
+MARKETING_VERSION = 7.1.1
 CURRENT_PROJECT_VERSION = 1


### PR DESCRIPTION
## Summary
This PR updates the ConsumerVPN sample apps to use **VPNKit SDK v7.1.1**.

## Key Highlights
- `sortedServer()` now returns the latest updated server list instead of cached data.
- Renamed property in `VPNConfiguration`: `shouldSkipVirtualServers` → `skipVirtualServerInLoadBalance`.
- Security update: IKEv2 Diffie-Hellman group updated from MODP 1024 to MODP 2048.
- IKEv2 encryption fix applied across iOS 26, macOS 26, and tvOS 26.

## Full Changelog
For a detailed list of all changes across versions (**v7.0.0 → v7.1.1**), please refer to the official [Changelog.md](https://github.com/wlvpn/ConsumerVPN-iOS/pull/11/files#diff-841633008b19b8748198e29f8acdde9001d9394a3f968f3099ef5eb6fc0f8539)